### PR TITLE
Allow using it for virtual attributes

### DIFF
--- a/lib/attribute_choices.rb
+++ b/lib/attribute_choices.rb
@@ -61,7 +61,7 @@ module AttributeChoices
 
       define_method("#{attribute.to_s}_display") do
         # The local variable `choices` is saved inside this Proc
-        tupple = choices.assoc(read_attribute(attribute))
+        tupple = choices.assoc(send(attribute))
         tupple && tupple.last
       end
 
@@ -81,7 +81,7 @@ module AttributeChoices
 
     private
     def assert_valid_attribute(attr_name)
-      unless column_names.include?(attr_name.to_s)
+      unless column_names.include?(attr_name.to_s) || (instance_methods.include?(attr_name) && instance_methods.include?("#{attr_name}="))
         raise ArgumentError, "Model attribute '#{attr_name.to_s}' doesn't exist" 
       end
     end

--- a/test/attribute_choices_test.rb
+++ b/test/attribute_choices_test.rb
@@ -41,6 +41,19 @@ class AttributeChoicesTest < ActiveSupport::TestCase
     end
   end
 
+  test "Allow specifying virtual attributes" do
+    assert_nothing_raised do
+      class Person < ActiveRecord::Base
+        attr_accessor :virtual_attribute
+        attribute_choices :virtual_attribute, {'w' => 'Wadus'}
+      end
+    end
+    
+    @person = Person.new(:virtual_attribute => 'w')
+    
+    assert_equal('Wadus', @person.virtual_attribute_display)
+  end
+
   test "Does not allow invalid option keys" do
     assert_raise ArgumentError do
       class Person < ActiveRecord::Base


### PR DESCRIPTION
Because storing things in databases is so 20th century...
